### PR TITLE
Use package hyperref to get access to href command

### DIFF
--- a/latex/preamble.tex
+++ b/latex/preamble.tex
@@ -14,6 +14,7 @@
 \renewcommand{\floatpagefraction}{0.75}
 
 \renewenvironment{quote}{\begin{VF}}{\end{VF}}
+\usepackage{hyperref}
 \let\oldhref\href
 \renewcommand{\href}[2]{#2\footnote{\url{#1}}}
 


### PR DESCRIPTION
This addresses Issue #15 I'm not sure why it worked a few weeks ago without this but this does fix it and allow hyperlinks in pdf.